### PR TITLE
Fix crashes due to "JS functions are not convertible to dynamic" errors

### DIFF
--- a/ReactCommon/jsi/jsi/JSIDynamic.cpp
+++ b/ReactCommon/jsi/jsi/JSIDynamic.cpp
@@ -83,6 +83,10 @@ folly::dynamic dynamicFromValue(Runtime& runtime, const Value& value) {
       // prop when we aren't supposed to.
       //
       // To avoid crashes, I've changed this to return `null` rather than throwing.
+      //
+      // See:
+      // - https://github.com/facebook/react-native/pull/28037
+      // - https://github.com/facebook/react-native/issues/27203
       return nullptr;
     } else {
       folly::dynamic ret = folly::dynamic::object();

--- a/ReactCommon/jsi/jsi/JSIDynamic.cpp
+++ b/ReactCommon/jsi/jsi/JSIDynamic.cpp
@@ -76,7 +76,14 @@ folly::dynamic dynamicFromValue(Runtime& runtime, const Value& value) {
       }
       return ret;
     } else if (obj.isFunction(runtime)) {
-      throw JSError(runtime, "JS Functions are not convertible to dynamic");
+      // throw JSError(runtime, "JS Functions are not convertible to dynamic");
+      //
+      // Peter note (2020-09-05): this was causing hard-to-track-down crashes
+      // on Android, likely because of somewhere where we're passing in a function
+      // prop when we aren't supposed to.
+      //
+      // To avoid crashes, I've changed this to return `null` rather than throwing.
+      return nullptr;
     } else {
       folly::dynamic ret = folly::dynamic::object();
       Array names = obj.getPropertyNames(runtime);


### PR DESCRIPTION
## Summary

We were getting errors on Bugsnag with the message:

> com.facebook.jni.CppException JS Functions are not convertible to dynamic
> 
> no stack 
>     NativeRunnable.java:-2 com.facebook.react.bridge.queue.NativeRunnable.run
>     Handler.java:883 android.os.Handler.handleCallback
>     Handler.java:100 android.os.Handler.dispatchMessage
>     MessageQueueThreadHandler.java:27 com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage
>     Looper.java:237 android.os.Looper.loop
>     MessageQueueThreadImpl.java:226 com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run
>     Thread.java:919 java.lang.Thread.run

https://app.bugsnag.com/travelchime-inc/travelchime/errors/5f50a86223f35800173ef285?filters[event.since][0]=30d&filters[error.status][0]=open

After investigating, this is definitely the line emitting the error, and it's likely due to a component being passed a native Javascript function as a prop where it's not expecting it (see https://github.com/hsource/react-native/blob/9a5c6df3c4b4fa21072017a58ab4dfed26b57a4d/ReactCommon/fabric/core/primitives/RawPropsParser.cpp#L126-L127)

After 2 hours of trying to debug this, though, I couldn't get native C++ error reporting working properly and decided to patch this using https://github.com/facebook/react-native/pull/28037

## Changelog

Android Fixed - Fix crashes due to "JS functions are not convertible to dynamic" errors

## Test Plan

N/A: mostly YOLO change