### PR TITLE
Fix bug with React Native images in XCode 12

### DIFF
--- a/Libraries/Image/RCTUIImageViewAnimated.m
+++ b/Libraries/Image/RCTUIImageViewAnimated.m
@@ -275,6 +275,8 @@ static NSUInteger RCTDeviceFreeMemory() {
   if (_currentFrame) {
     layer.contentsScale = self.animatedImageScale;
     layer.contents = (__bridge id)_currentFrame.CGImage;
+  } else {
+    [super displayLayer:layer];
   }
 }
 


### PR DESCRIPTION
## Summary

Fix images not showing up and the app crashing in XCode 12 by applying the patch in https://github.com/facebook/react-native/issues/29279#issuecomment-658244428

After upgrading to XCode 12, new builds of the app crash and don't display all images.

## Test Plan

Installed the branch into the app, and made sure images display again:

(In itineraries package.json:

```json
"react-native": "hsource/react-native#peter-ios-14",
```