### PR TITLE
Unset certain environment variables so NVM doesn't conflict

### DIFF
--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -4,7 +4,22 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Added fix from https://github.com/facebook/react-native/issues/31259#issuecomment-814949865
+# for error message:
+#
+# > /bin/sh -c .../Debug-iphonesimulator/FBReactNativeSpec.build/Script-F45532E0C9BBF654A0883132EA6E54FB.sh
+# > nvm is not compatible with the "PREFIX" environment variable: currently set
+# > to "/usr/local"
+# > Run `unset PREFIX` to unset it.
+#
+# > Command PhaseScriptExecution failed with a nonzero exit code
+# > PhaseScriptExecution [CP-User]\ Generate\ Specs
+# > .../FBReactNativeSpec.build/Script-F45532E0C9BBF654A0883132EA6E54FB.sh
+unset npm_config_prefix
+unset PREFIX
+
 set -e
+
 
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
## Summary

Fixes issue from https://github.com/react-native-community/upgrade-support/issues/138#issue-830850577: when building using `yarn ios --simulator`, we were getting an error:

```
/bin/sh -c /Users/peter/Library/Developer/Xcode/DerivedData/wanderlog-hjfmgebdscvpydbwysphulatplgz/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/FBReactNativeSpec.build/Script-F45532E0C9BBF654A0883132EA6E54FB.sh
nvm is not compatible with the "PREFIX" environment variable: currently set to "/usr/local"
Run `unset PREFIX` to unset it.
Command PhaseScriptExecution failed with a nonzero exit code
```

## Changelog

[General] [Fixed] - Fix iOS build issues when NVM is installed

## Test Plan

Ran `yarn ios --simulator` with given changes with NVM installed and verified that the app built properly
