### PR TITLE
Wrap NullPointerExceptions when thrown by native code called from JS

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
@@ -370,21 +370,27 @@ public class JavaMethodWrapper implements NativeModule.NativeMethod {
 
       try {
         mMethod.invoke(mModuleWrapper.getModule(), mArguments);
-      } catch (IllegalArgumentException ie) {
-        throw new RuntimeException("Could not invoke " + traceName, ie);
-      } catch (IllegalAccessException iae) {
-        throw new RuntimeException("Could not invoke " + traceName, iae);
+      } catch (IllegalArgumentException | IllegalAccessException | NullPointerException e) {
+        throw new RuntimeException(createInvokeExceptionMessage(traceName, parameters), e);
       } catch (InvocationTargetException ite) {
         // Exceptions thrown from native module calls end up wrapped in InvocationTargetException
         // which just make traces harder to read and bump out useful information
         if (ite.getCause() instanceof RuntimeException) {
           throw (RuntimeException) ite.getCause();
         }
-        throw new RuntimeException("Could not invoke " + traceName, ite);
+        throw new RuntimeException(createInvokeExceptionMessage(traceName, parameters), ite);
       }
     } finally {
       SystraceMessage.endSection(TRACE_TAG_REACT_JAVA_BRIDGE).flush();
     }
+  }
+
+  /**
+   * Makes it easier to determine the cause of an error invoking a native method from Javascript
+   * code by adding the function and parameters.
+   */
+  private static String createInvokeExceptionMessage(String traceName, ReadableArray parameters) {
+    return "Could not invoke " + traceName + " with parameters " + parameters.toArrayList();
   }
 
   /**


### PR DESCRIPTION
## Motivation

We're getting a lot of NullPointerExceptions in Bugsnag and it's hard to tell what code it's actually from:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'double java.lang.Double.doubleValue()' on a null object reference
        at com.facebook.react.bridge.ReadableNativeArray.getDouble(ReadableNativeArray.java:92)
        at com.facebook.react.bridge.JavaMethodWrapper$4.extractArgument(JavaMethodWrapper.java:64)
        at com.facebook.react.bridge.JavaMethodWrapper$4.extractArgument(JavaMethodWrapper.java:60)
        at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:356)
        at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:188)
        at com.facebook.jni.NativeRunnable.run(NativeRunnable.java:-2)
        at android.os.Handler.handleCallback(Handler.java:942)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
        at android.os.Looper.loopOnce(Looper.java:226)
        at android.os.Looper.loop(Looper.java:313)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:228)
        at java.lang.Thread.run(Thread.java:1012)
```

Reading through [this Github comment](https://github.com/facebook/react-native/issues/23126#issuecomment-545711780), it's possible to get called method's name from the `JavaMethodWrapper` `invoke` function. In fact, some other exceptions do have it wrapped like that.

## Fix

1. Also wrap NullPointerExceptions
2. Log the thrown error

## Testing

N/A - this is a small fix that I'll just deploy