### PR TITLE
Change boost source to same open source as more recent react-native

### DIFF
--- a/WanderlogPatches.md
+++ b/WanderlogPatches.md
@@ -48,3 +48,6 @@ rebase on upstream's `main`
 - Prevent crash when runAnimationStep called with low frameTimeNanos
   - Summary: React Native was crashing on OnePlus and Oppo devices. This is a workaround
   - Pull request: https://github.com/facebook/react-native/pull/37487
+- Fixed boost download path for iOS
+  - Summary: The previous download for boost, required by React Native, no longer works. Updated the download to match the one currently pulled by react-native. This is a Wanderlog-only patch to match our fork to what's currently on React Native.
+  - Pull request: https://github.com/wanderlog/react-native/pull/6

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   }
   s.header_dir             = "cxxreact"
 
-  s.dependency "boost", "1.76.0"
+  s.dependency "boost", "1.84.0"
   s.dependency "DoubleConversion"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\"",
                                "DEFINES_MODULE" => "YES" }
 
-  s.dependency "boost", "1.76.0"
+  s.dependency "boost", "1.84.0"
   s.dependency "DoubleConversion"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"

--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -5,13 +5,13 @@
 
 Pod::Spec.new do |spec|
   spec.name = 'boost'
-  spec.version = '1.76.0'
+  spec.version = '1.84.0'
   spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
   spec.homepage = 'http://www.boost.org'
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
-  spec.source = { :http => 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2',
-                  :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
+  spec.source = { :git => "https://github.com/react-native-community/boost-for-react-native",
+                  :tag => "v1.84.0" }
 
   # Pinning to the same version as React.podspec.
   spec.platforms = { :ios => min_ios_version_supported }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The current source for react-native boost no longer works. We want to patch this so that we use the same boost source as the most recent react-native, which can be found in https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/cocoapods/helpers.rb

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] - Change boost source to be git and update the tag.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Run this as a patched package. Make sure the Podfile compiles properly