### PR TITLE
Change boost source to new working one

### DIFF
--- a/WanderlogPatches.md
+++ b/WanderlogPatches.md
@@ -48,3 +48,6 @@ rebase on upstream's `main`
 - Prevent crash when runAnimationStep called with low frameTimeNanos
   - Summary: React Native was crashing on OnePlus and Oppo devices. This is a workaround
   - Pull request: https://github.com/facebook/react-native/pull/37487
+- Fixed boost download path for iOS & Android builds
+  - Summary: The previous download for boost, required by React Native, no longer works. Updated the download to match the one currently pulled by react-native. This is a Wanderlog-only patch to match our fork to what's currently on React Native.
+  - Pull request: https://github.com/wanderlog/react-native/pull/8

--- a/packages/react-native/ReactAndroid/build.gradle
+++ b/packages/react-native/ReactAndroid/build.gradle
@@ -259,7 +259,9 @@ task createNativeDepsDirectories {
 }
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
-    src("https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION.replace("_", ".")}/source/boost_${BOOST_VERSION}.tar.gz")
+    // Previous source no longer works, so we need to update it to a working source of the same version.
+    // See GitHub thread discussing this issue: https://github.com/boostorg/boost/issues/843#issuecomment-2602280364
+    src("https://archives.boost.io/release/${BOOST_VERSION.replace("_", ".")}/source/boost_${BOOST_VERSION}.tar.gz")
     onlyIfModified(true)
     overwrite(false)
     retries(5)

--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -10,7 +10,9 @@ Pod::Spec.new do |spec|
   spec.homepage = 'http://www.boost.org'
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
-  spec.source = { :http => 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2',
+  # Previous source no longer works, so we need to update to new source of the same version.
+  # See GitHub thread discussing this issue: https://github.com/boostorg/boost/issues/843#issuecomment-2602280364
+  spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.gz',
                   :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
 
   # Pinning to the same version as React.podspec.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The previous boost source is no longer valid. Change the boost source to 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.gz', in accordance to https://github.com/boostorg/boost/issues/843#issuecomment-2606820291

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS | ANDROID] Change source to be 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.gz'.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Ran `./gradlew prepareBoost` successfully to completion